### PR TITLE
Manage ptr:record objects

### DIFF
--- a/flaskapp.py
+++ b/flaskapp.py
@@ -216,7 +216,6 @@ class NetworkView(object):
         return "%s.in-addr.arpa" % '.'.join(reversed(str(pget).split('.')))
 
 
-# noinspection PyProtectedMember
 class DataModel(object):
     def __init__(self):
         self.views = {

--- a/flaskapp.py
+++ b/flaskapp.py
@@ -3,12 +3,16 @@
 # https://www.infoblox.com/wp-content/uploads/infoblox-deployment-infoblox-rest-api.pdf
 
 import base64
-from pprint import pprint
+import sys
 
+import flask
 from flask import Flask
 from flask import jsonify
 from flask import request
 from flask_basicauth import BasicAuth
+from pprint import pprint
+
+
 
 app = Flask(__name__)
 app.config['BASIC_AUTH_USERNAME'] = 'admin'
@@ -38,8 +42,8 @@ class NetworkView(object):
 
     def __init__(self, uid=None, isdefault=False, name=None, viewtype='network', network=None, comment=None):
         # `ZG5zLm5ldHdvcmskMS4wLjAuMC8yNC8w` == `dns.network$1.0.0.0/24/0`
-        # self.uid = uid
-        # self.uid = (base64.b64encode(str.encode(str(viewtype) + '$' + str(network) + '$' + str(name)))).decode('utf-8')
+        #self.uid = uid
+        #self.uid = (base64.b64encode(str.encode(str(viewtype) + '$' + str(network) + '$' + str(name)))).decode('utf-8')
         if uid:
             self._uid = uid
         self.default = isdefault
@@ -56,7 +60,7 @@ class NetworkView(object):
         # CHILD: ZG5zLnpvbmUkLl9kZWZhdWx0LmFuc2libGUtZG5z ==
         #   dns.zone$._default.ansible-dns
 
-        """
+        '''
         $ for X in $(cat uuids.sorted.txt); do echo $X; echo $X | base64 -D ; echo ""; done;
         ZG5zLm5ldHdvcmskMTkyLjE2OC4xMC4wLzI0LzA
         dns.network$192.168.10.0/24
@@ -74,7 +78,7 @@ class NetworkView(object):
         dns.view$._default
         ZG5zLnpvbmUkLl9kZWZhdWx0LmFuc2libGUtZG5z
         dns.zone$._default.ansible-dns
-        """
+        '''
 
         if self._uid:
             return self._uid
@@ -86,7 +90,7 @@ class NetworkView(object):
         else:
             try:
                 uid += str.encode(self.viewtype)
-            except Exception:
+            except:
                 uid += self.viewtype
 
         uid += '$'
@@ -99,7 +103,7 @@ class NetworkView(object):
         else:
             try:
                 uid += str.encode(self.network)
-            except Exception:
+            except:
                 uid += self.network
         uid = str.encode(uid)
         uid = base64.b64encode(uid)
@@ -127,7 +131,7 @@ class NetworkView(object):
 
     @property
     def _ref(self):
-        """
+        '''
         (ansidev) jtanner-OSX:AP-NIOS_FLASK_MOCK jtanner$ curl -k -u admin:infoblox 'https://192.168.10.10/wapi/v2.1/network'
         [
             {
@@ -152,7 +156,7 @@ class NetworkView(object):
         ]
 
         network/ZG5zLm5ldHdvcmskMTkyLjE2OC4xMC4wLzI0LzA:192.168.10.0/24/default
-        """
+        '''
         # <WAPITYPE>/<REFDATA>:<NAME>[/<NAMEN>]
         if self.viewtype == 'network':
             out = self.viewtype
@@ -170,30 +174,30 @@ class NetworkView(object):
             out += self.name if self.ptrdname is None else self.get_ptr_name()
             out += '/'
             out += str(self.default).lower()
-        return out  # return self.viewtype + '/' + self.uid + ':' + self.name + '/' + str(self.default).lower()
+        return out
+        #return self.viewtype + '/' + self.uid + ':' + self.name + '/' + str(self.default).lower()
 
-    def to_dict(self, fields=None):
-        if fields is None:
-            fields = []
-        ddict = {'uid': self.uid,
-                 '_ref': self._ref,  # '_ref': self.uid,
-                 'is_default': self.default,
-                 'name': self.name,
-                 'ptrdname': self.ptrdname,
-                 'comment': self.comment,
-                 'extattrs': self.extattrs,
-                 'network_view': self.network_view,
-                 'network': self.network,
-                 'view': self.view,
-                 'viewtype': self.viewtype,
-                 'options': self.options,
-                 'fqdn': self.fqdn,
-                 'ipv4addrs': self.ipv4addrs,
-                 'ipv6addrs': self.ipv6addrs,
-                 'ipv4addr': self.ipv4addr,
-                 'ipv6addr': self.ipv6addr
-
-                 }
+    def to_dict(self, fields=[]):
+        ddict = {
+            'uid': self.uid,
+            '_ref': self._ref,
+            #'_ref': self.uid,
+            'is_default': self.default,
+            'name': self.name,
+            'ptrdname': self.ptrdname,
+            'comment': self.comment,
+            'extattrs': self.extattrs,
+            'network_view': self.network_view,
+            'network': self.network,
+            'view': self.view,
+            'viewtype': self.viewtype,
+            'options': self.options,
+            'fqdn': self.fqdn,
+            'ipv4addrs': self.ipv4addrs,
+            'ipv6addrs': self.ipv6addrs,
+            'ipv4addr': self.ipv4addr,
+            'ipv6addr': self.ipv6addr
+        }
         if fields:
             for x in fields:
                 if x not in ddict:
@@ -215,19 +219,28 @@ class NetworkView(object):
 # noinspection PyProtectedMember
 class DataModel(object):
     def __init__(self):
-        self.views = {'network': [NetworkView(uid='ZG5zLm5ldHdvcmtfdmlldyQw', isdefault=True, name='default', network='1.0.0.0/24')],
-                      'networkview': [NetworkView(uid='ZG5zLm5ldHdvcmtfdmlldyQw', isdefault=True, name='default', network='1.0.0.0/24')],
-                      'ipv6network': [NetworkView(uid='ZG5zLm5ldHdvcmskZmU4MDo6LzY0LzA', isdefault=True, name='default', network='fe80::/64')], 'zone_auth': [],
-                      'view': [NetworkView(isdefault=True, name='default', viewtype='view')],
-                      'record:host': [],
-                      'record:ptr': [], }  # ZG5zLm5ldHdvcmtfdmlldyQw == dns.network_view$0  # ZG5zLm5ldHdvcmskZmU4MDo6LzY0LzA == dns.network$fe80::/64
+        self.views = {
+            'network': [NetworkView(uid='ZG5zLm5ldHdvcmtfdmlldyQw', isdefault=True, name='default', network='1.0.0.0/24')],
+            'networkview': [NetworkView(uid='ZG5zLm5ldHdvcmtfdmlldyQw', isdefault=True, name='default', network='1.0.0.0/24')],
+            'ipv6network': [NetworkView(uid='ZG5zLm5ldHdvcmskZmU4MDo6LzY0LzA', isdefault=True, name='default', network='fe80::/64')],
+            'zone_auth': [],
+            'view': [NetworkView(isdefault=True, name='default', viewtype='view')],
+            'record:host': [],
+            'record:ptr': [],
+        }
+        # ZG5zLm5ldHdvcmtfdmlldyQw == dns.network_view$0
+        # ZG5zLm5ldHdvcmskZmU4MDo6LzY0LzA == dns.network$fe80::/64
 
     def create_view(self, payload, viewtype='view', parent=None):
         # '{"name": "ansible-dns", "network_view": "default"}'
         # res = DATA.create_view(request.get_json())
-        print('########### VIEWTYPE: ' + viewtype)
-        name = payload.get('name', None)
-        view = NetworkView(uid=None, isdefault=False, name=name, viewtype=viewtype)
+        print ('########### VIEWTYPE: ' + viewtype)
+        view = NetworkView(
+            uid=None,
+            isdefault=False,
+            name=payload.get('name', ''),
+            viewtype=viewtype
+        )
         '''
         if payload.get('network'):
             view.network = payload['network']
@@ -238,28 +251,29 @@ class DataModel(object):
         '''
         if parent:
             view.parent = parent
-        for k, v in payload.items():
+        for k,v in payload.items():
             setattr(view, k, v)
         self.views[viewtype].append(view)
         return view
 
     def delete_view_by_refid(self, refid, viewtype=None):
-        for k, v in self.views.items():
+        for k,v in self.views.items():
             if viewtype and viewtype != k:
                 continue
-            for idx, x in enumerate(v):
+            for idx,x in enumerate(v):
                 if x._ref == refid:
                     print('REMOVING %s' % x._ref)
-                    self.views[k].remove(x)  # break
+                    self.views[k].remove(x)
+                    #break
 
     def update_view_by_refid(self, refid, params):
         print('# UPDATING REFID %s' % refid)
-        # refid = refid.replace('view', 'networkview')
+        #refid = refid.replace('view', 'networkview')
         viewk = None
         viewix = None
         changed = False
-        for k, v in self.views.items():
-            for idx, x in enumerate(v):
+        for k,v in self.views.items():
+            for idx,x in enumerate(v):
                 if x._refid != refid:
                     print('# %s != %s' % (x._refid, refid))
                 else:
@@ -267,7 +281,7 @@ class DataModel(object):
                 if x._ref == refid:
                     viewk = k
                     viewix = idx
-                    for pk, pv in params.items():
+                    for pk,pv in params.items():
                         print('# pk: %s pv: %s' % (pk, pv))
                         if pk == 'options':
                             # INPUT ...
@@ -285,12 +299,12 @@ class DataModel(object):
                             if not opts:
                                 opts = pv[:]
                             else:
-                                for idr, reqopt in enumerate(pv):
+                                for idr,reqopt in enumerate(pv):
                                     isset = False
-                                    for idv, viewopt in enumerate(opts):
+                                    for idv,viewopt in enumerate(opts):
                                         if viewopt.get('name') != reqopt.get('name'):
                                             continue
-                                        for rk, rv in reqopt.items():
+                                        for rk,rv in reqopt.items():
                                             opts[idv][rk] = rv
                                         isset = False
                                     if not isset:
@@ -346,7 +360,7 @@ class DataModel(object):
 
     def serialize_views(self, viewtype=None, name=None):
         res = []
-        for k, v in self.views.items():
+        for k,v in self.views.items():
             if viewtype and viewtype != k:
                 continue
             if name:
@@ -360,15 +374,13 @@ class DataModel(object):
         return res
 
     def serialize_view(self, view_type, name=None):
-        # print('serializing %s view' % view_type)
+        #print('serializing %s view' % view_type)
         res = [x.to_dict() for x in self.views[view_type]]
         return res
 
-    def serialize_view_by_refid(self, refid, returnfields=None):
-        if returnfields is None:
-            returnfields = []
+    def serialize_view_by_refid(self, refid, returnfields=[]):
         view = None
-        for k, v in self.views.items():
+        for k,v in self.views.items():
             for x in v:
                 if x._ref == refid:
                     view = x
@@ -381,27 +393,27 @@ class DataModel(object):
 DATA = DataModel()
 
 
-# noinspection PyProtectedMember
 @app.route('/wapi/v2.1/<viewtype>', methods=['GET', 'POST', 'PUT', 'DELETE'])
 def v21_base(viewtype):
-    # if viewtype != 'view':
+    #if viewtype != 'view':
     #    viewtype = viewtype.replace('view', '')
-    # print('VIEWTYPE: %s METHOD: %s' % (viewtype, request.method))
+    #print('VIEWTYPE: %s METHOD: %s' % (viewtype, request.method))
 
-    print('# METHOD: %s VIEWTYPE: %s' % (request.method, viewtype))
+    print('# METHOD: %s VIEWTYPE: %s' % (
+        request.method, viewtype
+    ))
     args = request.args.to_dict()
     print('# REQARGS ...')
     pprint(args)
     print('# REQJSON ...')
     try:
         pprint(request.get_json())
-    except Exception:
+    except:
         pprint({})
 
     if request.method == 'GET':
         print('# FETCHED VIEW ...')
         # payload = DATA.serialize_view(viewtype, name=args.get('name'))
-        print('# ARGS ...')
         name = args.get('name', None)
         if name is None:
             name = args.get('ptrdname', None)
@@ -419,13 +431,13 @@ def v21_base(viewtype):
 
     return jsonify({})
 
-
 # /wapi/v2.1/network/bmV0d29yayQxLjAuMC4wLzI0JGRlZmF1bHQ%3D%3A1.0.0.0/24/default
-# @app.route('/wapi/v2.1/<viewtype>/<refid>/<subname>', methods=['GET', 'POST', 'PUT', 'DELETE'])
-# @app.route('/wapi/v2.1/<viewtype>/<refid>/<subname>/subsubname', methods=['GET', 'POST', 'PUT', 'DELETE'])
+#@app.route('/wapi/v2.1/<viewtype>/<refid>/<subname>', methods=['GET', 'POST', 'PUT', 'DELETE'])
+#@app.route('/wapi/v2.1/<viewtype>/<refid>/<subname>/subsubname', methods=['GET', 'POST', 'PUT', 'DELETE'])
 @app.route('/wapi/v2.1/<viewtype>/<path:refpath>', methods=['GET', 'POST', 'PUT', 'DELETE'])
 def v21_abstractview_ref(viewtype, refid=None, subname=None, refpath=None, subsubname=None):
-    """
+
+    '''
     _refid = 'view/' + refid + '/' + subname
     __refid = refid.split(':')[0]
     if viewtype != 'view':
@@ -434,12 +446,14 @@ def v21_abstractview_ref(viewtype, refid=None, subname=None, refpath=None, subsu
     print('VIEWTYPE: %s METHOD: %s REFID: %s _REFID: %s' % (
         viewtype, request.method, __refid, _refid
     ))
-    """
+    '''
 
     print('# REFPATH: %s' % refpath)
     _refid = viewtype + '/' + refpath
     uid = refpath.split('/')[1].split(':')[0]
-    print('# METHOD: %s VIEWTYPE: %s UID: %s _REFID: %s' % (request.method, viewtype, uid, _refid))
+    print('# METHOD: %s VIEWTYPE: %s UID: %s _REFID: %s' % (
+        request.method, viewtype, uid, _refid
+    ))
 
     args = request.args.to_dict()
     print('# REQARGS ...')
@@ -447,7 +461,7 @@ def v21_abstractview_ref(viewtype, refid=None, subname=None, refpath=None, subsu
     print('# REQJSON ...')
     try:
         pprint(request.get_json())
-    except Exception:
+    except:
         pprint({})
 
     if request.method == 'GET':
@@ -463,7 +477,7 @@ def v21_abstractview_ref(viewtype, refid=None, subname=None, refpath=None, subsu
         return jsonify(view.to_dict()), 201
     elif request.method == 'PUT':
         view = DATA.update_view_by_refid(_refid, request.get_json())
-        # view = DATA.update_view_by_uid(__refid, request.get_json())
+        #view = DATA.update_view_by_uid(__refid, request.get_json())
         if not view:
             print('# ERROR!!! MODIFYING [%s] RETURN NO VIEW!' % _refid)
             return jsonify({})
@@ -477,7 +491,7 @@ def v21_abstractview_ref(viewtype, refid=None, subname=None, refpath=None, subsu
         return jsonify({})
 
     print('default return ...')
-    # return ''
+    #return ''
     return jsonify({})
 
 


### PR DESCRIPTION
SUMMARY
It seems that your `Flask Infoblox Server` from the test container: 
https://github.com/ansible/nios-test-container/blob/master/flaskapp.py  
*does not handle the record:ptr object*

```python
[]
127.0.0.1 - - [03/Jul/2018 20:13:24] "GET /wapi/v2.1/record%3Aptr?ipv4addr=192.168.10.1&ptrdname=host.ansible.com&_return_fields=name%2Cview%2Cipv4addr%2Cptrdname%2Cttl%2Cextattrs%2Ccomment&_max_results=1000&_proxy_search=GM HTTP/1.1" 200 -
# METHOD: POST VIEWTYPE: record:ptr
# REQARGS ...
{}
# REQJSON ...
{'ipv4addr': '192.168.10.1', 'ptrdname': 'host.ansible.com'}
# CREATE VIEWTYPE: record:ptr
########### VIEWTYPE: record:ptr
127.0.0.1 - - [03/Jul/2018 20:13:25] "POST /wapi/v2.1/record%3Aptr HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/home/clement/Documents/PROJECTS/ansible_env_setup/ansible/venv/lib/python3.6/site-packages/flask/app.py", line 2309, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/clement/Documents/PROJECTS/ansible_env_setup/ansible/venv/lib/python3.6/site-packages/flask/app.py", line 2295, in wsgi_app
    response = self.handle_exception(e)
  File "/home/clement/Documents/PROJECTS/ansible_env_setup/ansible/venv/lib/python3.6/site-packages/flask/app.py", line 1741, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/clement/Documents/PROJECTS/ansible_env_setup/ansible/venv/lib/python3.6/site-packages/flask/_compat.py", line 35, in reraise
    raise value
  File "/home/clement/Documents/PROJECTS/ansible_env_setup/ansible/venv/lib/python3.6/site-packages/flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/clement/Documents/PROJECTS/ansible_env_setup/ansible/venv/lib/python3.6/site-packages/flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/clement/Documents/PROJECTS/ansible_env_setup/ansible/venv/lib/python3.6/site-packages/flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/clement/Documents/PROJECTS/ansible_env_setup/ansible/venv/lib/python3.6/site-packages/flask/_compat.py", line 35, in reraise
    raise value
  File "/home/clement/Documents/PROJECTS/ansible_env_setup/ansible/venv/lib/python3.6/site-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/clement/Documents/PROJECTS/ansible_env_setup/ansible/venv/lib/python3.6/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/clement/Documents/PROJECTS/playbooks/nios_ansible_ptr_module/nios-test-container/flaskapp.py", line 407, in v21_base
    view = DATA.create_view(request.get_json(), viewtype=viewtype)
  File "/home/clement/Documents/PROJECTS/playbooks/nios_ansible_ptr_module/nios-test-container/flaskapp.py", line 240, in create_view
    self.views[viewtype].append(view)
KeyError: 'record:ptr'
```
Managing the record:ptr  did the trick.

*The Integration and target tests pass*

```bash
(venv) [clement@clemo nios_ansible_ptr_module]$ ansible-playbook -i inventory  nios_ptr_record_test_playbook.yml  --e="ansible_python_interpreter=$(which python)" 

PLAY [DNS] *********************************************************************************************************************************************************************

TASK [nios_ptr : create an ipv4 ptr record name=ptr.ansible.com, ptrdname=ptr.ansible.com, ipv4=192.168.10.1, state=present, provider={{ nios_provider }}, view=default] *******
Wednesday 04 July 2018  01:42:54 +0200 (0:00:00.228)       0:00:00.228 ******** 
changed: [127.0.0.1]

TASK [nios_ptr : create the same ipv4 ptr record name=ptr.ansible.com, ptrdname=ptr.ansible.com, ipv4=192.168.10.1, state=present, view=default, provider={{ nios_provider }}] ***
Wednesday 04 July 2018  01:42:55 +0200 (0:00:01.007)       0:00:01.235 ******** 
ok: [127.0.0.1]

TASK [nios_ptr : add a comment to an existing ipv4 ptr record name=ptr.ansible.com, ptrdname=ptr.ansible.com, ipv4=192.168.10.1, comment=this is a test comment, state=present, provider={{ nios_provider }}] ***
Wednesday 04 July 2018  01:42:56 +0200 (0:00:00.871)       0:00:02.106 ******** 
changed: [127.0.0.1]

TASK [nios_ptr : add the same comment to the same ipv4 ptr host record name=ptr.ansible.com, ptrdname=ptr.ansible.com, ipv4=192.168.10.1, comment=this is a test comment, state=present, provider={{ nios_provider }}] ***
Wednesday 04 July 2018  01:42:57 +0200 (0:00:00.843)       0:00:02.950 ******** 
ok: [127.0.0.1]

TASK [nios_ptr : remove a ptr record from the system name=ptr.ansible.com, ptrdname=ptr.ansible.com, ipv4=192.168.10.1, state=absent, provider={{ nios_provider }}] ************
Wednesday 04 July 2018  01:42:58 +0200 (0:00:00.866)       0:00:03.817 ******** 
changed: [127.0.0.1]

TASK [nios_ptr : remove the same ptr record from the system ptrdname=ptr.ansible.com, name=ptr.ansible.com, ipv4=192.168.10.1, state=absent, provider={{ nios_provider }}] *****
Wednesday 04 July 2018  01:42:59 +0200 (0:00:00.835)       0:00:04.652 ******** 
ok: [127.0.0.1]

TASK [nios_ptr : assert that=['ipv4_ptr_create1.changed', 'not ipv4_ptr_create2.changed', 'ipv4_ptr_update1.changed', 'not ipv4_ptr_update2.changed', 'ipv4_ptr_delete1.changed', 'not ipv4_ptr_delete2.changed']] ***
Wednesday 04 July 2018  01:42:59 +0200 (0:00:00.855)       0:00:05.508 ******** 
ok: [127.0.0.1] => {
    "changed": false,
    "msg": "All assertions passed"
}

PLAY RECAP *********************************************************************************************************************************************************************
127.0.0.1                  : ok=7    changed=3    unreachable=0    failed=0   

Wednesday 04 July 2018  01:42:59 +0200 (0:00:00.077)       0:00:05.585 ******** 
=============================================================================== 
nios_ptr : create an ipv4 ptr record ------------------------------------------------------------------------------------------------------------------------------------ 1.01s
nios_ptr : create the same ipv4 ptr record ------------------------------------------------------------------------------------------------------------------------------ 0.87s
nios_ptr : add the same comment to the same ipv4 ptr host record -------------------------------------------------------------------------------------------------------- 0.87s
nios_ptr : remove the same ptr record from the system ------------------------------------------------------------------------------------------------------------------- 0.86s
nios_ptr : add a comment to an existing ipv4 ptr record ----------------------------------------------------------------------------------------------------------------- 0.84s
nios_ptr : remove a ptr record from the system -------------------------------------------------------------------------------------------------------------------------- 0.84s
nios_ptr : assert ------------------------------------------------------------------------------------------------------------------------------------------------------- 0.08s
Playbook run took 0 days, 0 hours, 0 minutes, 5 seconds
(venv) [clement@clemo nios_ansible_ptr_module]$ 
```
*As well in the fake infoblox server*

```bash
(venv) [root@clemo clement]# python /home/clement/Documents/PROJECTS/playbooks/nios_ansible_ptr_module/nios-test-container/flaskapp.py
 * Serving Flask app "flaskapp" (lazy loading)
 * Environment: production
   WARNING: Do not use the development server in a production environment.
   Use a production WSGI server instead.
 * Debug mode: off
 * Running on https://0.0.0.0:443/ (Press CTRL+C to quit)
# METHOD: GET VIEWTYPE: record:ptr
# REQARGS ...
{'_max_results': '1000',
 '_return_fields': 'name,view,ipv4addr,ptrdname,ttl,extattrs,comment',
 'ipv4addr': '192.168.10.1',
 'ptrdname': 'ptr.ansible.com'}
# REQJSON ...
{}
# FETCHED VIEW ...
# ARGS ...
# filtering all in record:ptr by name ptr.ansible.com
[]
[]
[]
127.0.0.1 - - [04/Jul/2018 01:42:55] "GET /wapi/v2.1/record%3Aptr?ipv4addr=192.168.10.1&ptrdname=ptr.ansible.com&_return_fields=name%2Cview%2Cipv4addr%2Cptrdname%2Cttl%2Cextattrs%2Ccomment&_max_results=1000 HTTP/1.1" 200 -
# METHOD: GET VIEWTYPE: record:ptr
# REQARGS ...
{'_max_results': '1000',
 '_proxy_search': 'GM',
 '_return_fields': 'name,view,ipv4addr,ptrdname,ttl,extattrs,comment',
 'ipv4addr': '192.168.10.1',
 'ptrdname': 'ptr.ansible.com'}
# REQJSON ...
{}
# FETCHED VIEW ...
# ARGS ...
# filtering all in record:ptr by name ptr.ansible.com
[]
[]
[]
127.0.0.1 - - [04/Jul/2018 01:42:55] "GET /wapi/v2.1/record%3Aptr?ipv4addr=192.168.10.1&ptrdname=ptr.ansible.com&_return_fields=name%2Cview%2Cipv4addr%2Cptrdname%2Cttl%2Cextattrs%2Ccomment&_max_results=1000&_proxy_search=GM HTTP/1.1" 200 -
# METHOD: POST VIEWTYPE: record:ptr
# REQARGS ...
{}
# REQJSON ...
{'ipv4addr': '192.168.10.1',
 'name': 'ptr.ansible.com',
 'ptrdname': 'ptr.ansible.com',
 'view': 'default'}
# CREATE VIEWTYPE: record:ptr
########### VIEWTYPE: record:ptr
# CREATED VIEW ...
{'_ref': 'record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false',
 'comment': None,
 'extattrs': {},
 'fqdn': None,
 'ipv4addr': '192.168.10.1',
 'ipv4addrs': [],
 'ipv6addr': None,
 'ipv6addrs': [],
 'is_default': False,
 'name': 'ptr.ansible.com',
 'network': None,
 'network_view': 'default',
 'options': [],
 'ptrdname': 'ptr.ansible.com',
 'uid': 'ZG5zLnJlY29yZDpwdHIkTm9uZQ==',
 'view': 'default',
 'viewtype': 'record:ptr'}
127.0.0.1 - - [04/Jul/2018 01:42:55] "POST /wapi/v2.1/record%3Aptr HTTP/1.1" 201 -
# METHOD: GET VIEWTYPE: record:ptr
# REQARGS ...
{'_max_results': '1000',
 '_return_fields': 'name,view,ipv4addr,ptrdname,ttl,extattrs,comment',
 'ipv4addr': '192.168.10.1',
 'ptrdname': 'ptr.ansible.com'}
# REQJSON ...
{}
# FETCHED VIEW ...
# ARGS ...
# filtering all in record:ptr by name ptr.ansible.com
[<__main__.NetworkView object at 0x7f717ec6f860>]
['ptr.ansible.com']
[{'_ref': 'record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false',
  'comment': None,
  'extattrs': {},
  'fqdn': None,
  'ipv4addr': '192.168.10.1',
  'ipv4addrs': [],
  'ipv6addr': None,
  'ipv6addrs': [],
  'is_default': False,
  'name': 'ptr.ansible.com',
  'network': None,
  'network_view': 'default',
  'options': [],
  'ptrdname': 'ptr.ansible.com',
  'uid': 'ZG5zLnJlY29yZDpwdHIkTm9uZQ==',
  'view': 'default',
  'viewtype': 'record:ptr'}]
127.0.0.1 - - [04/Jul/2018 01:42:56] "GET /wapi/v2.1/record%3Aptr?ipv4addr=192.168.10.1&ptrdname=ptr.ansible.com&_return_fields=name%2Cview%2Cipv4addr%2Cptrdname%2Cttl%2Cextattrs%2Ccomment&_max_results=1000 HTTP/1.1" 200 -
# METHOD: GET VIEWTYPE: record:ptr
# REQARGS ...
{'_max_results': '1000',
 '_return_fields': 'name,view,ipv4addr,ptrdname,ttl,extattrs,comment',
 'ipv4addr': '192.168.10.1',
 'ptrdname': 'ptr.ansible.com'}
# REQJSON ...
{}
# FETCHED VIEW ...
# ARGS ...
# filtering all in record:ptr by name ptr.ansible.com
[<__main__.NetworkView object at 0x7f717ec6f860>]
['ptr.ansible.com']
[{'_ref': 'record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false',
  'comment': None,
  'extattrs': {},
  'fqdn': None,
  'ipv4addr': '192.168.10.1',
  'ipv4addrs': [],
  'ipv6addr': None,
  'ipv6addrs': [],
  'is_default': False,
  'name': 'ptr.ansible.com',
  'network': None,
  'network_view': 'default',
  'options': [],
  'ptrdname': 'ptr.ansible.com',
  'uid': 'ZG5zLnJlY29yZDpwdHIkTm9uZQ==',
  'view': 'default',
  'viewtype': 'record:ptr'}]
127.0.0.1 - - [04/Jul/2018 01:42:57] "GET /wapi/v2.1/record%3Aptr?ipv4addr=192.168.10.1&ptrdname=ptr.ansible.com&_return_fields=name%2Cview%2Cipv4addr%2Cptrdname%2Cttl%2Cextattrs%2Ccomment&_max_results=1000 HTTP/1.1" 200 -
# REFPATH: ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false
# METHOD: PUT VIEWTYPE: record:ptr UID: false _REFID: record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false
# REQARGS ...
{}
# REQJSON ...
{'comment': 'this is a test comment',
 'ipv4addr': '192.168.10.1',
 'name': 'ptr.ansible.com',
 'ptrdname': 'ptr.ansible.com'}
# UPDATING REFID record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false
# network/ZG5zLm5ldHdvcmtfdmlldyQw:1.0.0.0/24/default != record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false
# network/ZG5zLm5ldHdvcmtfdmlldyQw:1.0.0.0/24/default != record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false
# network/ZG5zLm5ldHdvcmskZmU4MDo6LzY0LzA:fe80::/64/default != record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false
# view/ZG5zLnZpZXckTm9uZQ==:default/true != record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false
# record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false == record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false
# pk: name pv: ptr.ansible.com
# pk: ipv4addr pv: 192.168.10.1
# pk: ptrdname pv: ptr.ansible.com
# pk: comment pv: this is a test comment
comment is "None" on record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false
setting comment to "this is a test comment" on record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false
# record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false updated? True
# viewk: record:ptr
# viewix: 0
# accessing found view
# return <__main__.NetworkView object at 0x7f717ec6f860>
# MODIFIED VIEW [ZG5zLnJlY29yZDpwdHIkTm9uZQ==] ...
{'_ref': 'record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false',
 'comment': 'this is a test comment',
 'extattrs': {},
 'fqdn': None,
 'ipv4addr': '192.168.10.1',
 'ipv4addrs': [],
 'ipv6addr': None,
 'ipv6addrs': [],
 'is_default': False,
 'name': 'ptr.ansible.com',
 'network': None,
 'network_view': 'default',
 'options': [],
 'ptrdname': 'ptr.ansible.com',
 'uid': 'ZG5zLnJlY29yZDpwdHIkTm9uZQ==',
 'view': 'default',
 'viewtype': 'record:ptr'}
127.0.0.1 - - [04/Jul/2018 01:42:57] "PUT /wapi/v2.1/record%3Aptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ%3D%3D%3A1.10.168.192.in-addr.arpa/false HTTP/1.1" 200 -
# METHOD: GET VIEWTYPE: record:ptr
# REQARGS ...
{'_max_results': '1000',
 '_return_fields': 'name,view,ipv4addr,ptrdname,ttl,extattrs,comment',
 'ipv4addr': '192.168.10.1',
 'ptrdname': 'ptr.ansible.com'}
# REQJSON ...
{}
# FETCHED VIEW ...
# ARGS ...
# filtering all in record:ptr by name ptr.ansible.com
[<__main__.NetworkView object at 0x7f717ec6f860>]
['ptr.ansible.com']
[{'_ref': 'record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false',
  'comment': 'this is a test comment',
  'extattrs': {},
  'fqdn': None,
  'ipv4addr': '192.168.10.1',
  'ipv4addrs': [],
  'ipv6addr': None,
  'ipv6addrs': [],
  'is_default': False,
  'name': 'ptr.ansible.com',
  'network': None,
  'network_view': 'default',
  'options': [],
  'ptrdname': 'ptr.ansible.com',
  'uid': 'ZG5zLnJlY29yZDpwdHIkTm9uZQ==',
  'view': 'default',
  'viewtype': 'record:ptr'}]
127.0.0.1 - - [04/Jul/2018 01:42:58] "GET /wapi/v2.1/record%3Aptr?ipv4addr=192.168.10.1&ptrdname=ptr.ansible.com&_return_fields=name%2Cview%2Cipv4addr%2Cptrdname%2Cttl%2Cextattrs%2Ccomment&_max_results=1000 HTTP/1.1" 200 -
# METHOD: GET VIEWTYPE: record:ptr
# REQARGS ...
{'_max_results': '1000',
 '_return_fields': 'name,view,ipv4addr,ptrdname,ttl,extattrs,comment',
 'ipv4addr': '192.168.10.1',
 'ptrdname': 'ptr.ansible.com'}
# REQJSON ...
{}
# FETCHED VIEW ...
# ARGS ...
# filtering all in record:ptr by name ptr.ansible.com
[<__main__.NetworkView object at 0x7f717ec6f860>]
['ptr.ansible.com']
[{'_ref': 'record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false',
  'comment': 'this is a test comment',
  'extattrs': {},
  'fqdn': None,
  'ipv4addr': '192.168.10.1',
  'ipv4addrs': [],
  'ipv6addr': None,
  'ipv6addrs': [],
  'is_default': False,
  'name': 'ptr.ansible.com',
  'network': None,
  'network_view': 'default',
  'options': [],
  'ptrdname': 'ptr.ansible.com',
  'uid': 'ZG5zLnJlY29yZDpwdHIkTm9uZQ==',
  'view': 'default',
  'viewtype': 'record:ptr'}]
127.0.0.1 - - [04/Jul/2018 01:42:58] "GET /wapi/v2.1/record%3Aptr?ipv4addr=192.168.10.1&ptrdname=ptr.ansible.com&_return_fields=name%2Cview%2Cipv4addr%2Cptrdname%2Cttl%2Cextattrs%2Ccomment&_max_results=1000 HTTP/1.1" 200 -
# REFPATH: ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false
# METHOD: DELETE VIEWTYPE: record:ptr UID: false _REFID: record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false
# REQARGS ...
{}
# REQJSON ...
{}
# DELETE VIEW [record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false]
REMOVING record:ptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ==:1.10.168.192.in-addr.arpa/false
# collecting all in record:ptr
[]
127.0.0.1 - - [04/Jul/2018 01:42:58] "DELETE /wapi/v2.1/record%3Aptr/ZG5zLnJlY29yZDpwdHIkTm9uZQ%3D%3D%3A1.10.168.192.in-addr.arpa/false HTTP/1.1" 200 -
# METHOD: GET VIEWTYPE: record:ptr
# REQARGS ...
{'_max_results': '1000',
 '_return_fields': 'name,view,ipv4addr,ptrdname,ttl,extattrs,comment',
 'ipv4addr': '192.168.10.1',
 'ptrdname': 'ptr.ansible.com'}
# REQJSON ...
{}
# FETCHED VIEW ...
# ARGS ...
# filtering all in record:ptr by name ptr.ansible.com
[]
[]
[]
127.0.0.1 - - [04/Jul/2018 01:42:59] "GET /wapi/v2.1/record%3Aptr?ipv4addr=192.168.10.1&ptrdname=ptr.ansible.com&_return_fields=name%2Cview%2Cipv4addr%2Cptrdname%2Cttl%2Cextattrs%2Ccomment&_max_results=1000 HTTP/1.1" 200 -
# METHOD: GET VIEWTYPE: record:ptr
# REQARGS ...
{'_max_results': '1000',
 '_proxy_search': 'GM',
 '_return_fields': 'name,view,ipv4addr,ptrdname,ttl,extattrs,comment',
 'ipv4addr': '192.168.10.1',
 'ptrdname': 'ptr.ansible.com'}
# REQJSON ...
{}
# FETCHED VIEW ...
# ARGS ...
# filtering all in record:ptr by name ptr.ansible.com
[]
[]
[]
127.0.0.1 - - [04/Jul/2018 01:42:59] "GET /wapi/v2.1/record%3Aptr?ipv4addr=192.168.10.1&ptrdname=ptr.ansible.com&_return_fields=name%2Cview%2Cipv4addr%2Cptrdname%2Cttl%2Cextattrs%2Ccomment&_max_results=1000&_proxy_search=GM HTTP/1.1" 200 -
```
- This fixes the integration test for the PR: https://github.com/ansible/ansible/pull/41900

ISSUE TYPE
Feature Pull Request
COMPONENT NAME
flaskapp.py
