### PR TITLE
Create additional nsgroup objects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.6
+FROM alpine:3.14
 
 ADD flaskapp.py /root/flaskapp.py
 ADD requirements.txt /root/requirements.txt
-RUN apk add --no-cache build-base openssl-dev libffi-dev python3 python3-dev py3-pip
+RUN apk add --no-cache build-base openssl-dev libffi-dev python3 python3-dev py3-pip cargo
 RUN pip3 install -r /root/requirements.txt
 EXPOSE 443
 CMD /usr/bin/python3 /root/flaskapp.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.15
 
 ADD flaskapp.py /root/flaskapp.py
 ADD requirements.txt /root/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.14
 
 ADD flaskapp.py /root/flaskapp.py
 ADD requirements.txt /root/requirements.txt
-RUN apk add --no-cache build-base openssl-dev libffi-dev python3 python3-dev py3-pip cargo
+RUN apk add --no-cache build-base python3 py3-wheel py3-pip py3-cryptography
 RUN pip3 install -r /root/requirements.txt
 EXPOSE 443
 CMD /usr/bin/python3 /root/flaskapp.py

--- a/flaskapp.py
+++ b/flaskapp.py
@@ -57,6 +57,9 @@ class NetworkView(object):
     grid_secondaries = None
     ns_group = None
     delegate_to = []
+    forwarding_servers = []
+    external_servers = []
+    stub_members = []
 
     def __init__(self, uid=None, isdefault=False, name=None, viewtype='network', network=None, comment=None):
         # `ZG5zLm5ldHdvcmskMS4wLjAuMC8yNC8w` == `dns.network$1.0.0.0/24/0`
@@ -232,7 +235,10 @@ class NetworkView(object):
             'grid_primary': self.grid_primary,
             'grid_secondaries': self.grid_secondaries,
             'ns_group': self.ns_group,
-            'delegate_to': self.delegate_to
+            'delegate_to': self.delegate_to,
+            'forwarding_servers': self.forwarding_servers,
+            'external_servers': self.external_servers,
+            'stub_members': self.stub_members
         }
         if fields:
             for x in fields:
@@ -270,6 +276,9 @@ class DataModel(object):
             'record:naptr': [],
             'record:txt': [],
             'nsgroup:delegation': [],
+            'nsgroup:forwardingmember': [],
+            'nsgroup:forwardstubserver': [],
+            'nsgroup:stubmember': []
         }
         # ZG5zLm5ldHdvcmtfdmlldyQw == dns.network_view$0
         # ZG5zLm5ldHdvcmskZmU4MDo6LzY0LzA == dns.network$fe80::/64

--- a/flaskapp.py
+++ b/flaskapp.py
@@ -56,6 +56,7 @@ class NetworkView(object):
     grid_primary = None
     grid_secondaries = None
     ns_group = None
+    delegate_to = []
 
     def __init__(self, uid=None, isdefault=False, name=None, viewtype='network', network=None, comment=None):
         # `ZG5zLm5ldHdvcmskMS4wLjAuMC8yNC8w` == `dns.network$1.0.0.0/24/0`
@@ -230,7 +231,8 @@ class NetworkView(object):
             'zone_format': self.zone_format,
             'grid_primary': self.grid_primary,
             'grid_secondaries': self.grid_secondaries,
-            'ns_group': self.ns_group
+            'ns_group': self.ns_group,
+            'delegate_to': self.delegate_to
         }
         if fields:
             for x in fields:
@@ -266,7 +268,8 @@ class DataModel(object):
             'record:mx': [],
             'record:srv': [],
             'record:naptr': [],
-            'record:txt': []
+            'record:txt': [],
+            'nsgroup:delegation': [],
         }
         # ZG5zLm5ldHdvcmtfdmlldyQw == dns.network_view$0
         # ZG5zLm5ldHdvcmskZmU4MDo6LzY0LzA == dns.network$fe80::/64

--- a/flaskapp.py
+++ b/flaskapp.py
@@ -278,7 +278,7 @@ class DataModel(object):
             'nsgroup:delegation': [],
             'nsgroup:forwardingmember': [],
             'nsgroup:forwardstubserver': [],
-            'nsgroup:stubmember': []
+            'nsgroup:stubmember': [],
         }
         # ZG5zLm5ldHdvcmtfdmlldyQw == dns.network_view$0
         # ZG5zLm5ldHdvcmskZmU4MDo6LzY0LzA == dns.network$fe80::/64

--- a/flaskapp.py
+++ b/flaskapp.py
@@ -238,7 +238,7 @@ class NetworkView(object):
             'delegate_to': self.delegate_to,
             'forwarding_servers': self.forwarding_servers,
             'external_servers': self.external_servers,
-            'stub_members': self.stub_members
+            'stub_members': self.stub_members,
         }
         if fields:
             for x in fields:


### PR DESCRIPTION
As required for https://github.com/infobloxopen/infoblox-ansible/pull/56, I patched this app to add support for the additional nsgroup objects.

However, I found a couple of problems during my build, which may need some further attention before merging:

1. During image build, there was an error to compile the `cryptography` Python package, which required installing `cargo` via `apk`.
2. The `rust` version installed on Alpine 3.6 is too old, so I updated the Dockerfile to use 3.14 instead.

Please, let me know your thoughts about this.

(CC: @anagha-infoblox)